### PR TITLE
MNT add pre-commit-hooks

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,11 +32,17 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --requirement requirements.txt --upgrade --quiet --use-feature=2020-resolver
-        pip install pytest
+        pip install pytest black isort
         python --version
         pip --version
         pip list
       shell: bash
+
+    - name: Check black
+      run: black --check --diff .
+
+    - name: Check isort
+      run: isort --check --diff .
 
     - name: Tests
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: check-yaml
+        exclude: .github/conda/meta.yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+        types: [file, python]
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort

--- a/modelcards/cards.py
+++ b/modelcards/cards.py
@@ -8,7 +8,9 @@ import yaml
 from huggingface_hub import hf_hub_download, upload_file
 
 TEMPLATE_MODELCARD_PATH = Path(__file__).parent / "modelcard_template.md"
-REGEX_YAML_BLOCK = re.compile(r"---[\n\r]+([\S\s]*?)[\n\r]+---[\n\r]([\S\s].*)", re.DOTALL)
+REGEX_YAML_BLOCK = re.compile(
+    r"---[\n\r]+([\S\s]*?)[\n\r]+---[\n\r]([\S\s].*)", re.DOTALL
+)
 
 
 class RepoCard:
@@ -47,7 +49,7 @@ class RepoCard:
             tmp_path.write_text(str(self))
             upload_file(
                 path_or_fileobj=str(tmp_path),
-                path_in_repo='README.md',
+                path_in_repo="README.md",
                 repo_id=repo_id,
                 repo_type=repo_type,
                 identical_ok=True,
@@ -77,12 +79,12 @@ class ModelCard(RepoCard):
             metrics = [metrics]
 
         card_data = {
-            'language': language,
-            'license': license,
-            'library_name': library_name,
-            'tags': tags,
-            'dataset': dataset,
-            'metrics': metrics,
+            "language": language,
+            "license": license,
+            "library_name": library_name,
+            "tags": tags,
+            "dataset": dataset,
+            "metrics": metrics,
         }
         content = jinja2.Template(Path(template_path).read_text()).render(
             card_data=yaml.dump(card_data, sort_keys=False).strip(), **template_kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target_version = ['py37', 'py38', 'py39', 'py310']
+preview = true
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,12 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="modelcards",
-    version='0.0.3',
+    version="0.0.3",
     author="Nathan Raw",
     author_email="naterawdata@gmail.com",
-    description="📝 Utility to create, edit, and publish model cards on the Hugging Face Hub.",
+    description=(
+        "📝 Utility to create, edit, and publish model cards on the Hugging Face Hub."
+    ),
     license="MIT",
     install_requires=requirements,
     packages=find_packages(),

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,77 +1,85 @@
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from modelcards import ModelCard, RepoCard
 
 
 def test_load_repocard_from_file():
-    sample_path = Path(__file__).parent / 'samples' / "sample_1.md"
+    sample_path = Path(__file__).parent / "samples" / "sample_1.md"
     card = RepoCard.load(sample_path)
     assert card.data == {
-        'language': ['en'],
-        'license': 'mit',
-        'library_name': 'pytorch-lightning',
-        'tags': ['pytorch', 'image-classification'],
-        'dataset': ['beans'],
-        'metrics': ['acc'],
+        "language": ["en"],
+        "license": "mit",
+        "library_name": "pytorch-lightning",
+        "tags": ["pytorch", "image-classification"],
+        "dataset": ["beans"],
+        "metrics": ["acc"],
     }
-    assert card.text.strip().startswith("# my-cool-model"), "Card text not loaded properly"
+    assert card.text.strip().startswith(
+        "# my-cool-model"
+    ), "Card text not loaded properly"
 
 
 def test_change_repocard_data():
-    sample_path = Path(__file__).parent / 'samples' / "sample_1.md"
+    sample_path = Path(__file__).parent / "samples" / "sample_1.md"
     card = RepoCard.load(sample_path)
-    card.data['language'] = ['fr']
+    card.data["language"] = ["fr"]
 
     with tempfile.TemporaryDirectory() as tempdir:
         updated_card_path = Path(tempdir) / "updated.md"
         card.save(updated_card_path)
 
         updated_card = RepoCard.load(updated_card_path)
-        assert updated_card.data['language'] == ['fr'], "Card data not updated properly"
+        assert updated_card.data["language"] == ["fr"], "Card data not updated properly"
 
 
 def test_model_card_from_default_template():
 
     card = ModelCard.from_template(
-        language='en',
-        license='mit',
-        library_name='pytorch',
-        tags=['image-classification', 'resnet'],
-        dataset='imagenet',
-        metrics=['acc', 'f1'],
+        language="en",
+        license="mit",
+        library_name="pytorch",
+        tags=["image-classification", "resnet"],
+        dataset="imagenet",
+        metrics=["acc", "f1"],
         model_id=None,
     )
-    assert card.data['language'] == ['en'], "Set language card data should be list not string"
-    assert card.text.strip().startswith("# MyModelName"), "Default model name not set correctly"
+    assert card.data["language"] == [
+        "en"
+    ], "Set language card data should be list not string"
+    assert card.text.strip().startswith(
+        "# MyModelName"
+    ), "Default model name not set correctly"
 
 
 def test_model_card_from_default_template_with_model_id():
     card = ModelCard.from_template(
-        language='en',
-        license='mit',
-        library_name='pytorch',
-        tags=['image-classification', 'resnet'],
-        dataset='imagenet',
-        metrics=['acc', 'f1'],
+        language="en",
+        license="mit",
+        library_name="pytorch",
+        tags=["image-classification", "resnet"],
+        dataset="imagenet",
+        metrics=["acc", "f1"],
         model_id="my-cool-model",
     )
-    assert card.text.strip().startswith("# my-cool-model"), "model_id not properly set in card template"
+    assert card.text.strip().startswith(
+        "# my-cool-model"
+    ), "model_id not properly set in card template"
 
 
 def test_model_card_from_custom_template():
-    template_path = Path(__file__).parent / 'samples' / "sample_template.md"
+    template_path = Path(__file__).parent / "samples" / "sample_template.md"
     card = ModelCard.from_template(
-        language='en',
-        license='mit',
-        library_name='pytorch',
+        language="en",
+        license="mit",
+        library_name="pytorch",
         tags="text-classification",
-        dataset='glue',
-        metrics='acc',
+        dataset="glue",
+        metrics="acc",
         template_path=template_path,
-        some_data='asdf',
+        some_data="asdf",
     )
 
-    assert card.text.endswith('asdf'), "Custom template didn't set jinja variable correctly"
+    assert card.text.endswith(
+        "asdf"
+    ), "Custom template didn't set jinja variable correctly"


### PR DESCRIPTION
This PR adds the pre-commit hooks to keep the code style in sync with `huggingface_hub`.

One needs to enable them with `pre-commit install` on the local copy for them to take effect, by default they're not used.