### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/modelcards/__init__.py
+++ b/modelcards/__init__.py
@@ -1,4 +1,8 @@
+# flake8: noqa
+# There's no way to ignore "F401 '...' imported but unused" warnings in this
+# module, but to preserve other warnings. So, don't check this module at all.
+
 from .card_data import CardData, EvalResult
 from .cards import ModelCard, RepoCard
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,22 @@
 from setuptools import find_packages, setup
 
+
+def get_version() -> str:
+    rel_path = "modelcards/__init__.py"
+    with open(rel_path, "r") as fp:
+        for line in fp.read().splitlines():
+            if line.startswith("__version__"):
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
+
+
 with open("requirements.txt", "r") as f:
     requirements = f.read().splitlines()
 
 setup(
     name="modelcards",
-    version="0.0.3",
+    version=get_version(),
     author="Nathan Raw",
     author_email="naterawdata@gmail.com",
     description=(


### PR DESCRIPTION
Bumping version in preparation for releasing 0.0.4. Also added `get_version()` in `setup.py` and ignored `flake8` errors in `modelcards/__init__.py`. 