### PR TITLE
Allow for missing metadata, invalid model-index

### DIFF
--- a/tests/samples/sample_invalid_card_data.md
+++ b/tests/samples/sample_invalid_card_data.md
@@ -4,4 +4,4 @@
 
 # invalid-card-data
 
-This card should fail when trying to load it in.
+This card should fail when trying to load it in because the card data between the `---` is a list instead of a dict.

--- a/tests/samples/sample_invalid_model_index.md
+++ b/tests/samples/sample_invalid_model_index.md
@@ -1,0 +1,24 @@
+---
+language: en
+license: mit
+library_name: timm
+tags:
+- pytorch
+- image-classification
+datasets:
+- beans
+metrics:
+- acc
+model-index:
+- name: my-cool-model
+  results:
+  - task:
+      type: image-classification
+    metrics:
+    - type: acc
+      value: 0.9
+---
+
+# Invalid Model Index
+
+In this example, the model index does not define a dataset field. In this case, we'll still initialize CardData, but will leave model-index/eval_results out of it.

--- a/tests/samples/sample_no_metadata.md
+++ b/tests/samples/sample_no_metadata.md
@@ -1,0 +1,3 @@
+# MyCoolModel
+
+In this example, we don't have any metadata at the top of the file. In cases like these, `CardData` should be instantiated as empty.


### PR DESCRIPTION
This PR fixes issues when you load cards that:
- Have no metadata (i.e. a regular readme)
- Have invalid model index (like if you didn't put a 'dataset' field in your model-index results) (Resolves #13)
  - in this case we initialize card data without any eval_results, even results were listed in `model-index` (since the model index was invalid)