### PR TITLE
Deep copy card data when calling to_dict

### DIFF
--- a/modelcards/card_data.py
+++ b/modelcards/card_data.py
@@ -1,3 +1,4 @@
+import copy
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
@@ -154,7 +155,7 @@ class CardData:
             block for inclusion in a README.md file.
         """
 
-        data_dict = self.__dict__
+        data_dict = copy.deepcopy(self.__dict__)
         if self.eval_results is not None:
             data_dict["model-index"] = eval_results_to_model_index(
                 self.model_name, self.eval_results


### PR DESCRIPTION
If we don't deep copy here, the reference we are using still mutates the original underlying class's attribute dict. This makes it so `model-index` becomes a key and `card_data.eval_results` gets removed.