### PR TITLE
Fix libraries link

### DIFF
--- a/modelcards/card_data.py
+++ b/modelcards/card_data.py
@@ -96,7 +96,7 @@ class CardData:
                 https://hf.co/docs/hub/model-repos#list-of-license-identifiers. Defaults to None.
             library_name (str, *optional*):
                 Name of library used by this model. Example: keras or any library from
-                https://github.com/huggingface/huggingface_hub/blob/main/js/src/lib/interfaces/Libraries.ts.
+                https://github.com/huggingface/hub-docs/blob/main/js/src/lib/interfaces/Libraries.ts.
                 Defaults to None.
             tags (List[str], *optional*):
                 List of tags to add to your model that can be used when filtering on the Hugging


### PR DESCRIPTION
The link to guidance on libraries was wrong, so updating that here. 