### PR TITLE
Add modelcard validation by hitting hub endpoint

### DIFF
--- a/modelcards/cards.py
+++ b/modelcards/cards.py
@@ -132,10 +132,16 @@ class RepoCard:
         }
         headers = {"Accept": "text/plain"}
 
-        r = requests.post("https://huggingface.co/validate-yaml", body, headers=headers)
-
-        if r.status_code == 400:
-            raise RuntimeError(r.content)  # b'- Error: YAML....'
+        try:
+            r = requests.post(
+                "https://huggingface.co/validate-yaml", body, headers=headers
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            if r.status_code == 400:
+                raise RuntimeError(r.text)
+            else:
+                raise exc
 
     def push_to_hub(self, repo_id, token=None, repo_type=None):
         """Push a RepoCard to a Hugging Face Hub repo.

--- a/modelcards/cards.py
+++ b/modelcards/cards.py
@@ -130,7 +130,9 @@ class RepoCard:
             "repoId": "huggingface/some-repo-name",
             "content": str(self),
         }
-        r = requests.get("https://huggingface.co/validate-yaml", body)
+        headers = {"Accept": "text/plain"}
+
+        r = requests.post("https://huggingface.co/validate-yaml", body, headers=headers)
 
         if r.status_code == 400:
             raise RuntimeError(r.content)  # b'- Error: YAML....'

--- a/modelcards/cards.py
+++ b/modelcards/cards.py
@@ -127,7 +127,6 @@ class RepoCard:
 
         body = {
             "repoType": repo_type,
-            "repoId": "huggingface/some-repo-name",
             "content": str(self),
         }
         headers = {"Accept": "text/plain"}

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -115,3 +115,15 @@ def test_model_card_with_invalid_model_index(caplog):
         card = ModelCard.load(sample_path)
     assert "Invalid model-index. Not loading eval results into CardData." in caplog.text
     assert card.data.eval_results is None
+
+
+def test_validate_modelcard(caplog):
+    sample_path = Path(__file__).parent / "samples" / "sample_simple.md"
+    card = RepoCard.load(sample_path)
+    card.validate()
+
+    card.data.license = "asdf"
+    with pytest.raises(
+        RuntimeError, match='- Error: YAML metadata schema issue on key "license"'
+    ):
+        card.validate()


### PR DESCRIPTION
This PR resolves #2 by adding a call to the Hugging Face API to validate card metadata before pushing to the hub. Since it requires the internet, we only call it when pushing to hub, as we can assume the user has access to the internet. 